### PR TITLE
Fix comments

### DIFF
--- a/docs/AKS-HCI/README.md
+++ b/docs/AKS-HCI/README.md
@@ -19,12 +19,11 @@ After following the setup documents, you can go through the sample notebooks lin
 
 * [Image Classification Using Scikit-learn](notebooks/mnist/MNIST_Training_with_AKS-HCI_Cluster_and_NFS.ipynb) (Image Classification)
 
-  This notebook serves as "hello world" of using for training and inference with AKS-HCI Cluster, on-premise NFS Server, and Azure Machine Learning. The estimated run time for the notebook is 20 minutes, including
+  This notebook serves as "hello world" of using for training and inference with AKS-HCI Cluster, on-premise NFS Server and Azure Machine Learning workspaces, including
   * Training with AKS-HCI cluster and on-premise NFS Server
   * Register model
   * Inference with the registered model on AKS-HCI cluster
   * Test model
-
 
 ## CLI v2 Examples
 
@@ -36,12 +35,11 @@ Follow this [document](https://docs.microsoft.com/en-us/azure/machine-learning/h
 
 * [Image Classification Using Scikit-learn](cli/mnist/README.md) (Image Classification)
 
-  This example serves as "hello world" of using for training and inference with AKS-HCI Cluster, on-premise NFS Server, and Azure Machine Learning workspaces. The estimated run time for the notebook is 20 minutes, including
+  This example serves as "hello world" of using for training and inference with AKS-HCI Cluster, on-premise NFS Server and Azure Machine Learning workspaces, including
   * Training with AKS-HCI cluster and on-premise NFS Server
   * Register model
   * Inference with the registered model on AKS-HCI cluster
   * Test model
-
 
 ## Troubleshooting
 

--- a/docs/AKS-HCI/cli/README.md
+++ b/docs/AKS-HCI/cli/README.md
@@ -10,12 +10,11 @@ Follow this [doc](https://docs.microsoft.com/en-us/azure/machine-learning/how-to
 
 ### Examples
 
-* [Image Classification Using Scikit-learn](mnist/README.md) (Image Classification, Aprox. 20 Minutes)
+* [Image Classification Using Scikit-learn](mnist/README.md) (Image Classification)
 
-  This example serves as "hello world" of using for training and inference with AKS-HCI Cluster, on-premise NFS Server and Azure Machine Learning workspaces. Estimated run time for the notebook is 20 minutes, including
+  This example serves as "hello world" of using for training and inference with AKS-HCI Cluster, on-premise NFS Server and Azure Machine Learning workspaces, including
   * Training with AKS-HCI cluster and on-premise NFS Server
   * Register model
   * Inference with registered model on AKS-HCI cluster
   * Test model
 
-Note: Above run time estimated assume a vm size comparable to [Standard_D8s_v3](https://docs.microsoft.com/en-us/azure-stack/aks-hci/concepts-support#supported-vm-sizes)

--- a/docs/AKS-HCI/cli/mnist/README.md
+++ b/docs/AKS-HCI/cli/mnist/README.md
@@ -121,7 +121,7 @@ mnist
 |-- sample-request.json
 |--...
 ```
-As you can see from above, "model" directory contains Conda environment definition, "score.py" is the scoring script. At top level directory, we have endpoint YAML definition and sample request JSON file. In general, this is very typical project setup for Azure Arc enabled ML model deployment.
+As you can see from above, "model" directory contains Conda environment definition, "[score.py](score.py)" is the scoring script. At top level directory, we have endpoint YAML definition and sample request JSON file. In general, this is very typical project setup for Azure Arc enabled ML model deployment.
 
 Replace the compute name, instance type name, model name / version in endpoint.yml, then trigger real-time endpoint deployment.
 ```
@@ -138,7 +138,7 @@ Check if deployment was successful
 ```
 az ml endpoint get-logs -n <endpoint_name> --deployment blue
 ```
-Get deployment logs. (The deployment name blue is defined in endpoint.yml)
+Get deployment logs. (The deployment name blue is defined in [endpoint.yml](endpoint.yml))
 
 8. Test endpoint by scoring request
 

--- a/docs/AKS-HCI/nfs/Verify_NFS_Setup_in_AMLArc.ipynb
+++ b/docs/AKS-HCI/nfs/Verify_NFS_Setup_in_AMLArc.ipynb
@@ -22,9 +22,9 @@
    "source": [
     "## Prerequisites\n",
     "\n",
-    "* [Setup Azure Arc-enabled Machine Learning Training and Inferencing on AKS on Azure Stack HCI](https://github.com/msftcoderdjw/AML-Kubernetes/blob/jiadu/aks-hci/docs/AKS-HCI/AML-ARC-Compute.md)\n",
+    "* [Setup Azure Arc-enabled Machine Learning Training and Inferencing on AKS on Azure Stack HCI](https://github.com/Azure/AML-Kubernetes/tree/master/docs/AKS-HCI/AML-ARC-Compute.md)\n",
     "\n",
-    "* [Setup NFS Server on Azure Stack HCI and Use your Data and run managed Machine Learning Experiments On-Premises](https://github.com/msftcoderdjw/AML-Kubernetes/blob/jiadu/aks-hci/docs/AKS-HCI/Train-AzureArc.md)\n",
+    "* [Setup NFS Server on Azure Stack HCI and Use your Data and run managed Machine Learning Experiments On-Premises](https://github.com/Azure/AML-Kubernetes/tree/master/docs/AKS-HCI/Train-AzureArc.md)\n",
     "\n",
     "* (Optional) Upload some training data to NFS Server for verification"
    ]
@@ -62,13 +62,13 @@
    "source": [
     "## Setup compute target\n",
     "\n",
-    "Find the Arc K8S Resource Id and replace the resource id below.\n",
+    "If you have done the compute target setup using [doc](https://github.com/Azure/AML-Kubernetes/tree/master/docs/AKS-HCI/AML-ARC-Compute.md#attach-your-azure-arc-enabled-cluster-to-your-azure-machine-learning-workspace-as-a-compute-target), you can replace the compute target name with `<ArcComputeName>` or give via environment variable AML_COMPUTE_CLUSTER_NAME, and leave resource_id as it is. Below script will fetch the compute your created.\n",
     "\n",
-    "e.g. /subscriptions/`<subscriptionId>`/resourceGroups/`<resourceGroupName>`/providers/Microsoft.Kubernetes/connectedClusters/`<clusterName>`\n",
-    "\n",
-    "Using 'kubectl create ns aml' to create a namespace in advance.\n",
-    "\n",
-    "Replace the arc compute name `<ArcComputeName>` or give via environment variable AML_COMPUTE_CLUSTER_NAME."
+    "Otherwise, provide both Arc K8S Resource Id and Compute Name to create a new compute target.\n",
+    "* Find the Arc K8S Resource Id and replace the resource id below.\n",
+    "  e.g. /subscriptions/`<subscriptionId>`/resourceGroups/`<resourceGroupName>`/providers/Microsoft.Kubernetes/connectedClusters/`<clusterName>`\n",
+    "* Using 'kubectl create ns aml' to create a namespace in advance.\n",
+    "* Replace the arc compute name `<ArcComputeName>` or give via environment variable AML_COMPUTE_CLUSTER_NAME."
    ]
   },
   {
@@ -199,7 +199,7 @@
    "source": [
     "### Configure the training job\n",
     "\n",
-    "The training (except for the env image build time) takes about 4 mins with vm size comparable to Standard_D8s_v3, `<MountPathOnTrainingPod>` is the same as the mountPath defined in mount-config.yaml."
+    "`<MountPathOnTrainingPod>` is the same as the mountPath defined in mount-config.yaml."
    ]
   },
   {

--- a/docs/AKS-HCI/notebooks/README.md
+++ b/docs/AKS-HCI/notebooks/README.md
@@ -4,12 +4,10 @@ After following the setup documents, you can go through the sample notebooks lin
 
 ## Notebooks
 
-* [Image Classification Using Scikit-learn](mnist/MNIST_Training_with_AKS-HCI_Cluster_and_NFS.ipynb) (Image Classification, Aprox. 20 Minutes)
+* [Image Classification Using Scikit-learn](mnist/MNIST_Training_with_AKS-HCI_Cluster_and_NFS.ipynb) (Image Classification)
 
-  This notebook serves as "hello world" of using for training and inference with AKS-HCI Cluster, on-premise NFS Server and Azure Machine Learning workspaces. Estimated run time for the notebook is 20 minutes, including
+  This notebook serves as "hello world" of using for training and inference with AKS-HCI Cluster, on-premise NFS Server and Azure Machine Learning workspaces, including
   * Training with AKS-HCI cluster and on-premise NFS Server
   * Register model
   * Inference with registered model on AKS-HCI cluster
   * Test model
-
-Note: Above run time estimated assume a vm size comparable to [Standard_D8s_v3](https://docs.microsoft.com/en-us/azure-stack/aks-hci/concepts-support#supported-vm-sizes)

--- a/docs/AKS-HCI/notebooks/mnist/MNIST_Training_with_AKS-HCI_Cluster_and_NFS.ipynb
+++ b/docs/AKS-HCI/notebooks/mnist/MNIST_Training_with_AKS-HCI_Cluster_and_NFS.ipynb
@@ -22,9 +22,9 @@
    "source": [
     "## Prerequisites\n",
     "\n",
-    "* [Setup Azure Arc-enabled Machine Learning Training and Inferencing on AKS on Azure Stack HCI](https://github.com/msftcoderdjw/AML-Kubernetes/blob/jiadu/aks-hci/docs/AKS-HCI/AML-ARC-Compute.md)\n",
+    "* [Setup Azure Arc-enabled Machine Learning Training and Inferencing on AKS on Azure Stack HCI](https://github.com/Azure/AML-Kubernetes/tree/master/docs/AKS-HCI/AML-ARC-Compute.md)\n",
     "\n",
-    "* [Setup NFS Server on Azure Stack HCI and Use your Data and run managed Machine Learning Experiments On-Premises](https://github.com/msftcoderdjw/AML-Kubernetes/blob/jiadu/aks-hci/docs/AKS-HCI/Train-AzureArc.md)\n",
+    "* [Setup NFS Server on Azure Stack HCI and Use your Data and run managed Machine Learning Experiments On-Premises](https://github.com/Azure/AML-Kubernetes/tree/master/docs/AKS-HCI/Train-AzureArc.md)\n",
     "\n",
     "* Make sure the NFS Server is mounted on the notebook execution machine. In this notebook, it will upload the training data to NFS Server.\n",
     "\n",
@@ -132,13 +132,13 @@
    "source": [
     "## Setup compute target\n",
     "\n",
-    "Find the Arc K8S Resource Id and replace the resource id below.\n",
+    "If you have done the compute target setup using [doc](https://github.com/Azure/AML-Kubernetes/tree/master/docs/AKS-HCI/AML-ARC-Compute.md#attach-your-azure-arc-enabled-cluster-to-your-azure-machine-learning-workspace-as-a-compute-target), you can replace the compute target name with `<ArcComputeName>` or give via environment variable AML_COMPUTE_CLUSTER_NAME, and leave resource_id as it is. Below script will fetch the compute your created.\n",
     "\n",
-    "e.g. /subscriptions/`<subscriptionId>`/resourceGroups/`<resourceGroupName>`/providers/Microsoft.Kubernetes/connectedClusters/`<clusterName>`\n",
-    "\n",
-    "Using 'kubectl create ns aml' to create a namespace in advance.\n",
-    "\n",
-    "Replace the arc compute name `<ArcComputeName>` or give via environment variable AML_COMPUTE_CLUSTER_NAME."
+    "Otherwise, provide both Arc K8S Resource Id and Compute Name to create a new compute target.\n",
+    "* Find the Arc K8S Resource Id and replace the resource id below.\n",
+    "  e.g. /subscriptions/`<subscriptionId>`/resourceGroups/`<resourceGroupName>`/providers/Microsoft.Kubernetes/connectedClusters/`<clusterName>`\n",
+    "* Using 'kubectl create ns aml' to create a namespace in advance.\n",
+    "* Replace the arc compute name `<ArcComputeName>` or give via environment variable AML_COMPUTE_CLUSTER_NAME."
    ]
   },
   {
@@ -267,7 +267,7 @@
    "source": [
     "### Configure the training job\n",
     "\n",
-    "The training (except for the env image build time) takes about 5 mins with vm size comparable to Standard_D8s_v3, `<MountPathOnTrainingPod>` is the same as the mountPath defined in mount-config.yaml."
+    "`<MountPathOnTrainingPod>` is the same as the mountPath defined in mount-config.yaml."
    ]
   },
   {


### PR DESCRIPTION
1. Remove all time estimation and vm size suggestion since the test HCI cluster is not production grade.
2. Add a notice in example notebooks / verify notebooks at Setup Compute Target. If users have setup the compute target, could only put the compute target name here.
3. Replace the hyper link and point to Azure/AML-Kubernetes repo.
4. Fix two wrong links in cli example.